### PR TITLE
Injecting underscore dependency into AMD module

### DIFF
--- a/backbone-route-filter-amd.js
+++ b/backbone-route-filter-amd.js
@@ -1,4 +1,4 @@
-define(['backbone'], function(Backbone){
+define(['backbone', 'underscore'], function(Backbone, _){
 
 	var extend = Backbone.Router.extend;
 

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
   },
   "dependencies": {
     "backbone": "~1.1.2",
-    "underscore": "1.8.2"
+    "underscore": "~1.8.2"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,7 @@
     "url": "git://github.com/chirag04/backbone-async-route-filter.git"
   },
   "dependencies": {
-    "backbone": "~1.1.2"
+    "backbone": "~1.1.2",
+    "underscore": "1.8.2"
   }
 }


### PR DESCRIPTION
We want to use this module with browserify, and it's complaining since underscore wasn't included in the module definition. Just adding that in.